### PR TITLE
fix: detect provider on refresh

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,13 @@
  */
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
-import { clusterApiUrl, Connection } from '@solana/web3.js';
 
-import {
-  getProvider,
-} from './utils';
+// TODO: Remove @solana/web3.js package?
+// import { clusterApiUrl, Connection } from '@solana/web3.js';
 
-import { TLog } from './types';
+import { getProvider } from './utils';
+
+import { TLog, Web3Provider } from './types';
 
 import { Logs, Sidebar, NoProvider } from './components';
 import { ethers } from 'ethers';
@@ -33,14 +33,10 @@ const StyledApp = styled.div`
 // Constants
 // =============================================================================
 
-// alternatively, use 'https://solana-api.projectserum.com' for demo purposes only
-const NETWORK = clusterApiUrl('mainnet-beta');
-const provider = getProvider();
-const anyWindow: any = window;
-const ethereum = anyWindow.ethereum
-let accounts = []
-const connection = new Connection(NETWORK);
+// const provider = getProvider();
+let accounts = [];
 const message = 'To avoid digital dognappers, sign below to authenticate with CryptoCorgis.';
+const sleep = (timeInMS) => new Promise((resolve) => setTimeout(resolve, timeInMS));
 
 // =============================================================================
 // Typedefs
@@ -60,6 +56,7 @@ interface Props {
   address: string | null;
   connectedMethods: ConnectedMethods[];
   handleConnect: () => Promise<void>;
+  provider: any;
   logs: TLog[];
   clearLogs: () => void;
 }
@@ -73,6 +70,7 @@ interface Props {
  * The fun stuff!
  */
 const useProps = (): Props => {
+  const [provider, setProvider] = useState<Web3Provider | null>(null);
   const [logs, setLogs] = useState<TLog[]>([]);
 
   const createLog = useCallback(
@@ -87,9 +85,16 @@ const useProps = (): Props => {
   }, [setLogs]);
 
   useEffect(() => {
-    if (!provider) return
+    (async () => {
+      await sleep(100);
+      setProvider(getProvider());
+    })();
+  }, []);
 
-    ethereum.on('connect', (connectionInfo: {chainId: string}) => {
+  useEffect(() => {
+    if (!provider) return;
+
+    provider.on('connect', (connectionInfo: { chainId: string }) => {
       createLog({
         status: 'success',
         method: 'connect',
@@ -97,7 +102,7 @@ const useProps = (): Props => {
       });
     });
 
-    ethereum.on('disconnect', () => {
+    provider.on('disconnect', () => {
       createLog({
         status: 'warning',
         method: 'disconnect',
@@ -105,9 +110,9 @@ const useProps = (): Props => {
       });
     });
 
-    ethereum.on('accountsChanged', (newAccounts: String[]) => {
+    provider.on('accountsChanged', (newAccounts: String[]) => {
       if (newAccounts) {
-        accounts = newAccounts
+        accounts = newAccounts;
         createLog({
           status: 'info',
           method: 'accountChanged',
@@ -144,34 +149,33 @@ const useProps = (): Props => {
         });
       }
     });
-
-  }, [createLog]);
+  }, [provider, createLog]);
 
   /** eth_sendTransaction */
   const handleEthSendTransaction = useCallback(async () => {
     if (!provider) return;
 
-    const signer = provider.getSigner()
-    const address = await signer.getAddress()
-    const gasPrice = await provider.getGasPrice()
+    const signer = provider.getSigner();
+    const address = await signer.getAddress();
+    const gasPrice = await provider.getGasPrice();
     const transactionParameters = {
       nonce: await provider.getTransactionCount(address), // ignored by Phantom
       gasPrice, // customizable by user during MetaMask confirmation.
       gasLimit: ethers.utils.hexlify(100000),
       to: address, // Required except during contract publications.
       from: address, // must match user's active address.
-      value: ethers.utils.parseUnits("1", "wei"), // Only required to send ether to the recipient from the initiating external account.
-      data: "0x2208b07b3c285f9998749c90d270a61c63230983054b5cf1ddee97ea763d3b22" // optional arbitrary hex data
+      value: ethers.utils.parseUnits('1', 'wei'), // Only required to send ether to the recipient from the initiating external account.
+      data: '0x2208b07b3c285f9998749c90d270a61c63230983054b5cf1ddee97ea763d3b22', // optional arbitrary hex data
     };
     try {
-      const transaction = await signer.sendTransaction(transactionParameters) 
+      const transaction = await signer.sendTransaction(transactionParameters);
       createLog({
         status: 'info',
         method: 'eth_sendTransaction',
         message: `Sending transaction: ${JSON.stringify(transaction)}`,
       });
       try {
-        const txReceipt =  await transaction.wait(1)
+        const txReceipt = await transaction.wait(1);
         createLog({
           status: 'info',
           method: 'eth_sendTransaction',
@@ -181,24 +185,24 @@ const useProps = (): Props => {
         createLog({
           status: 'error',
           method: 'eth_sendTransaction',
-          message: `Failed to include transaction on the chain: ${error.message}`
+          message: `Failed to include transaction on the chain: ${error.message}`,
         });
       }
     } catch (error) {
       createLog({
         status: 'error',
         method: 'eth_sendTransaction',
-        message: error.message
+        message: error.message,
       });
     }
-  }, [createLog]);
+  }, [provider, createLog]);
 
   /** SignMessage */
   const handleSignMessage = useCallback(async () => {
     if (!provider) return;
     try {
-      const signer = provider.getSigner()
-      const signature = await signer.signMessage(message)
+      const signer = provider.getSigner();
+      const signature = await signer.signMessage(message);
       createLog({
         status: 'success',
         method: 'signMessage',
@@ -212,14 +216,14 @@ const useProps = (): Props => {
         message: error.message,
       });
     }
-  }, [createLog]);
+  }, [provider, createLog]);
 
   /** Connect */
   const handleConnect = useCallback(async () => {
     if (!provider) return;
 
     try {
-      accounts = await provider.send( 'eth_requestAccounts', []);
+      accounts = await provider.send('eth_requestAccounts', []);
       createLog({
         status: 'success',
         method: 'connect',
@@ -232,7 +236,7 @@ const useProps = (): Props => {
         message: error.message,
       });
     }
-  }, [createLog]);
+  }, [provider, createLog]);
 
   const connectedMethods = useMemo(() => {
     return [
@@ -245,15 +249,13 @@ const useProps = (): Props => {
         onClick: handleSignMessage,
       },
     ];
-  }, [
-    handleEthSendTransaction,
-    handleSignMessage,
-  ]);
+  }, [handleEthSendTransaction, handleSignMessage]);
 
   return {
     address: accounts[0],
     connectedMethods,
     handleConnect,
+    provider,
     logs,
     clearLogs,
   };
@@ -281,7 +283,7 @@ const StatelessApp = React.memo((props: Props) => {
 const App = () => {
   const props = useProps();
 
-  if (!provider) {
+  if (!props.provider) {
     return <NoProvider />;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { PublicKey, Transaction, SendOptions } from '@solana/web3.js';
+import { providers } from 'ethers';
 
 type DisplayEncoding = 'utf8' | 'hex';
 
@@ -40,3 +41,5 @@ export interface TLog {
   message: string;
   messageTwo?: string;
 }
+
+export type Web3Provider = providers.Web3Provider;


### PR DESCRIPTION
This is a quick, hacky fix for detecting the provider on page refresh. We probably need a more elegant solution that polls on certain DOM events and when `window` is fully loaded. This is how the Solana Wallet Adapter currently does it: https://github.com/solana-labs/wallet-adapter/blob/8d1981af45b5abb1636ce028815291ad985074d3/packages/core/base/src/adapter.ts#L122-L163